### PR TITLE
Use encryptionSdk in the example for encryptData in Java example code

### DIFF
--- a/doc_source/implement-caching.md
+++ b/doc_source/implement-caching.md
@@ -134,7 +134,7 @@ If you are encrypting data streams, or any data of unknown size, be sure to spec
 // the encryption operation uses the data key cache
 //
 final AwsCrypto encryptionSdk = new AwsCrypto();
-byte[] message = new AwsCrypto().encryptData(cachingCmm, plaintext_source).getResult();
+byte[] message = encryptionSdk.encryptData(cachingCmm, plaintext_source).getResult();
 ```
 
 ------


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Modified the example to use the variable `encryptionSdk` defined in a previous row.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
