### PR TITLE
Error in How the SDK Decrypts an Encrypted Message

### DIFF
--- a/doc_source/how-it-works.md
+++ b/doc_source/how-it-works.md
@@ -77,7 +77,7 @@ The SDK provides methods that decrypt an encrypted message and return plaintext 
 
    To indicate the source of the [data keys](concepts.md#DEK) that were used to encrypt your data, your request specifies a cryptographic materials manager \(CMM\) or a master key provider\. \(If you specify a master key provider, the AWS Encryption SDK creates a default CMM that interacts with the specified master key provider\.\)
 
-1. The decryption method extracts the encrypted data key from the encrypted message\. Then, it asks the cryptographic materials manager \(CMM\) for a data key to decrypt the encrypted data key\.
+1. The decryption method extracts the encrypted data key from the encrypted message\. Then, it asks the cryptographic materials manager \(CMM\) for a data key to decrypt the encrypted data\.
 
 1. The CMM asks its master key provider for a master key that can decrypt the encrypted data key\. 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I'm reading the sdk decryption procedure description, and there's something I don't get : Why would we ask the CMM for a __data key__ to decrypt the encrypted __data key__?

Judging from the context and the rest of the procedure, I guess this is just a mistake and what is meant here is really "a data key to decrypt the encrypted data."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
