### PR TITLE
Update ESDK-Java Maven example to use 1.6.0

### DIFF
--- a/doc_source/java.md
+++ b/doc_source/java.md
@@ -44,7 +44,7 @@ The AWS Encryption SDK for Java is available through [Apache Maven](https://mave
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.3.1</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
*Description of changes:* The newest released version of AWS Encryption SDK for Java is [1.6.0](https://mvnrepository.com/artifact/com.amazonaws/aws-encryption-sdk-java/1.6.0). This updates the installation instructions to use that version instead of the older 1.3.1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
