### PR TITLE
Updates for C and JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,17 @@ examples that show common use patterns.
 
 The AWS Encryption SDK is a
 [client-side](https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/client-server-side.html)
-encryption library that makes it easier you to encrypt and decrypt data securely in your
+encryption library that makes it easier for you to encrypt and decrypt data securely in your
 application. It can be used on any type of data. The `encrypt`
 method returns a single, portable formatted message that is easy to store and manage. 
 
-It is available in [Java](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/java.html),
+The AWS Encryption SDK is available in [Java](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/java.html),
 [Python](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/python.html),
-[C](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/c-language.html) (as a preview
-release), and a [command-line
+[C](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/c-language.html), [JavaScript](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/javascript.html), and a [command-line
 interface](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/crypto-cli.html) that runs on Linux, macOS and Windows.
 
 
-To protect data, the Encryption SDK uses *envelope encryption*. Each item of data is encrypted under a unique data key. Then, the data key is encrypted under a master key so it can be safely stored with the data. The application does not have to generate or manage the data keys.
+To protect data, the Encryption SDK uses *envelope encryption*. Each item of data is encrypted under a unique data key. Then, the data key is encrypted under a master key so it can be safely stored with the data. Your application does not have to generate or manage the data keys.
 
 To protect the master key that encrypts the data keys, you can use a web service, such as [AWS Key
 Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/) (AWS KMS), a hardware
@@ -43,10 +42,11 @@ and examples in each programming language to help you get started.
 ## Where is the code?
 We are developing the AWS Encryption SDK in the following open source projects on GitHub. 
 
+* C - [aws-encryption-sdk-c](https://github.com/aws/aws-encryption-sdk-c)
 * Java - [aws-encryption-sdk-java](https://github.com/aws/aws-encryption-sdk-java)
+* JavaScript - [aws-encryption-sdk-javascript](https://github.com/aws/aws-encryption-sdk-javascript)
 * Python -
 [aws-encryption-sdk-python](https://github.com/aws/aws-encryption-sdk-python)
-* C (preview) - [aws-encryption-sdk-c](https://github.com/awslabs/aws-encryption-sdk-c)
 * Command-line interface - [aws-encryption-sdk-cli](https://github.com/awslabs/aws-encryption-sdk-cli)
 
 ## Who is the audience?


### PR DESCRIPTION
Update the readme. Both the Encryption SDK for C and the Encryption SDK for JavaScript are generally available in the ```aws``` organization on GitHub.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
