### PR TITLE
Fixed a variable name mismatch

### DIFF
--- a/doc_source/js-examples.md
+++ b/doc_source/js-examples.md
@@ -148,7 +148,7 @@ First, get the encryption context from the message header\. Then, verify that ea
 const { encryptionContext } = messageHeader
 
 Object
-  .entries(context)
+  .entries(encryptionContext)
   .forEach(([key, value]) => {
     if (encryptionContext[key] !== value) throw new Error('Encryption Context does not match expected values')
 })
@@ -158,7 +158,7 @@ Object
 const { encryptionContext } = messageHeader
 
 Object
-  .entries(context)
+  .entries(encryptionContext)
   .forEach(([key, value]) => {
     if (encryptionContext[key] !== value) throw new Error('Encryption Context does not match expected values')
 })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The example code looks like there is variable name mismatch between `encryptionContext` and `context`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
