### PR TITLE
Fix migrate-commitment-policy.md java typos

### DIFF
--- a/doc_source/migrate-commitment-policy.md
+++ b/doc_source/migrate-commitment-policy.md
@@ -129,8 +129,8 @@ For a complete example, see [SetCommitmentPolicyExample\.java](https://github.co
 
 ```
 // Instantiate the client
-final AwsCrypto crypto = AwsCrypto().builder()
-    .withCommmitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+final AwsCrypto crypto = AwsCrypto.builder()
+    .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
     .build();
 
 // Create a master key provider in strict mode


### PR DESCRIPTION
*Description of changes:*
Fix a few typos in java example code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
