### PR TITLE
Configuring KmsMasterKeyProvider using specific credentials

### DIFF
--- a/doc_source/java-example-code.md
+++ b/doc_source/java-example-code.md
@@ -74,6 +74,19 @@ public class BasicEncryptionExample {
         // To encrypt and decrypt with this master key provider, use an AWS KMS key ARN to identify the CMKs.
         // In strict mode, the decrypt operation requires a key ARN.
         final KmsMasterKeyProvider keyProvider = KmsMasterKeyProvider.builder().buildStrict(keyArn);
+        
+        OR
+        
+        // We can configure the KmsMasterKeyProvider to use specific credentials. 
+        // If a builder was previously set, this will override it.
+        // You can create an AWSCredentials object using AWS SDK for Java1.x
+        // Add access key and secret key of your IAM role
+        AWScredentials awsCredentials = new BasicAWSCredentials(accessKey,secretKey);
+        // now using this create a KmsMasterKeyProvider Object
+        final KmsMasterKeyProvider keyProvider = KmsMasterKeyProvider.builder()
+                                                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials)
+                                                .withDefaultRegion(region) // specify region
+                                                .buildStrict(keyArn); // pass the key ARN
 
         // 3. Create an encryption context
         // Most encrypted data should have an associated encryption context

--- a/doc_source/java-example-code.md
+++ b/doc_source/java-example-code.md
@@ -84,7 +84,7 @@ public class BasicEncryptionExample {
         AWScredentials awsCredentials = new BasicAWSCredentials(accessKey,secretKey);
         // now using this create a KmsMasterKeyProvider Object
         final KmsMasterKeyProvider keyProvider = KmsMasterKeyProvider.builder()
-                                                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials)
+                                                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                                                 .withDefaultRegion(region) // specify region
                                                 .buildStrict(keyArn); // pass the key ARN
 


### PR DESCRIPTION
Added a code snippet for the creation of KmsMasterKeyProvider object using your IAM role credentials. You can put your Access Key and Secret Key in the application(.properties/.yml) file or pass it as environment variables, 
 the code is basically creating an AWSCredentials type object, which is an Interface in AWS SDK for java1.x, Then we can configure the KmsMasterKeyProvider to use specific credentials.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
